### PR TITLE
Introduce ExampleFormat::$useModern flag to toggle unified Example[][] format for #[Examples] with backward compatibility.

### DIFF
--- a/src/Codeception/Test/ExampleFormat.php
+++ b/src/Codeception/Test/ExampleFormat.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Test;
+
+/**
+ * Controls the format returned by a single `#[Examples]` attribute.
+ *
+ *  • **false** (default value) ⇒ historical behavior:
+ *      - A single #[Examples]            ⇒ Example[]   (flat array)
+ *      - Multiple #[Examples] / @example ⇒ Example[][]
+ *
+ *  • **true** ⇒ new unified behavior (always Example[][]).
+ *
+ * Change the value —for example in tests/_bootstrap.php— like this:
+ *
+ *      \Codeception\Test\ExampleFormat::$useModern = true;
+ */
+class ExampleFormat
+{
+    /** @var bool */
+    public static bool $useModern = false;
+}

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -1,4 +1,6 @@
 <?php
 
 // Here you can initialize variables that will for your tests
-\Codeception\Configuration::$lock = true;
+
+\Codeception\Configuration::$lock           = true;
+\Codeception\Test\ExampleFormat::$useModern = true;


### PR DESCRIPTION
This PR is for illustrative purposes only